### PR TITLE
Added a localization guide for spanish translators

### DIFF
--- a/localization/localization-spanish/README.md
+++ b/localization/localization-spanish/README.md
@@ -13,7 +13,7 @@ Bienvenidas y bienvenidos a la wiki del equipo de traducción de elementary OS a
 
 _Esta guía no es una biblia inmutable e indiscutible._
 
-Es un conjunto de referencias y acuerdos entre las personas que han traducido elmentary al español que nos resultan convenientes a la hora de traducir el sistema operativo y sus aplicaciones. Y debido a que el español está en continua evolución, las recomendaciones que consignemos aquí hoy pueden cambiar.
+Es un conjunto de referencias y acuerdos entre las personas que han traducido elementary al español que nos resultan convenientes a la hora de traducir el sistema operativo y sus aplicaciones. Y debido a que el español está en continua evolución, las recomendaciones que consignemos aquí hoy pueden cambiar.
 
 Si tiene una petición, queja, reclamo o sugerencia constructiva, es más que bienvenida. Recomendamos iniciar la discusión en:
 

--- a/localization/localization-spanish/README.md
+++ b/localization/localization-spanish/README.md
@@ -133,7 +133,7 @@ Es importante mencionar que una gran parte de esta información se ha tomado de 
 
 Se recomienda leer y revisar frecuentemente estas guías para tener claro todos los aspectos de traducción al español para elementary OS.
 
-* Guía de estilo de Ubuntu al español: [Ubuntu Spanish Translators](https://wiki.ubuntu.com/UbuntuSpanishTranslators)
+* Guía de estilo de Ubuntu al español: [Ubuntu Spanish Translators](https://wiki.ubuntu.com/UbuntuSpanishTranslators/Estilo)
 * Guía de estilo de Fedora al español: [Fedora L10N Spanish Team](https://fedoraproject.org/wiki/L10N/Teams/Spanish/Diccionario)
 * Diccionario de términos técnicos e informáticos de Microsoft: [Microsoft Terminology](https://learn.microsoft.com/en-us/globalization/reference/microsoft-terminology) y [Microsoft Terminology Search](https://msit.powerbi.com/view?r=eyJrIjoiODJmYjU4Y2YtM2M0ZC00YzYxLWE1YTktNzFjYmYxNTAxNjQ0IiwidCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsImMiOjV9)
 * Manual de la RAE con diversos temas [Diccionario panhispánico de dudas](https://www.rae.es/dpd/)

--- a/localization/localization-spanish/README.md
+++ b/localization/localization-spanish/README.md
@@ -1,0 +1,143 @@
+# Tabla de contenidos
+
+* [Guía de estilo (este documento)](README.md)
+* [Glosario de términos](glossary.md)
+* [Prácticas recomendadas](best-practices.md)
+* [Errores comunes de traducción](common-errors.md)
+
+# Guía de estilo de elementary OS en español
+
+Bienvenidas y bienvenidos a la wiki del equipo de traducción de elementary OS al español. Esta guía habla de detalles específicos de elementary para la localización al español. Este documento pretende unificar las traducciones de todas las variantes del español y nos ayuda a tener una traducción coherente y unificada para elementary en nuestro idioma.
+
+# Sobre esta guía
+
+_Esta guía no es una biblia inmutable e indiscutible._
+
+Es un conjunto de referencias y acuerdos entre las personas que han traducido elmentary al español que nos resultan convenientes a la hora de traducir el sistema operativo y sus aplicaciones. Y debido a que el español está en continua evolución, las recomendaciones que consignemos aquí hoy pueden cambiar.
+
+Si tiene una petición, queja, reclamo o sugerencia constructiva, es más que bienvenida. Recomendamos iniciar la discusión en:
+
+* [El canal de Matrix de traducciones de elementary (en inglés)](https://matrix.to/#/%23elementary-l10n%3Amatrix.org) 
+
+* [La comunidad de Discord de elementary (en inglés)](https://discord.gg/vZZCBwZ6).
+
+# Aspectos específicos de elementary OS
+
+A continuación discutiremos sobre aspectos específicos de la traducción de elementary OS al idioma español.
+
+## El objetivo de _elementary OS_ como distribución
+
+La distribución de elementary OS pretende ser una distribución concisa y simple, pero potente. 
+
+Esto hace que las interfaces hacia el usuario deban ser simples, concisas y fáciles de entender para usuarios que no son ávidos consumidores de tecnología, o expertos en manejar sistemas. Pero, a su vez, un usuario con conocimientos puede darle un gran uso a su equipo en tareas del día a día y mucho más.
+
+Esto, como filosofía, debe representarse en toda traducción que se haga. En la práctica, lo que se evita es ser excesivamente técnico o abstracto y tratar siempre de virar hacia lo sencillo, conciso y claro.
+
+## Acerca de la localización regional
+
+En este instante no se tiene como objetivo tener localizaciones regionales. Estamos asumiendo la traducción al español como un español neutro, posible de entender para toda la región hispanoamericana.
+
+Esto significa que en Weblate, a pesar de que pueden existir otras regiones, en particular «Español (México)», o *es_MX*, no vamos a realizar traducciones en esa área, ya que no se piensan utilizar en elementary a futuro. Solamente tendremos actualizada la región principal, que en Weblate es *Español* a secas.
+
+## Sobre el nombre _elementary_ y sus variaciones
+
+El nombre elementary consiste de tres elementos:
+
+* elementary: Usualmente, se refiere al equipo de desarrollo.
+* elementary OS: El sistema operativo como tal.
+* elementary, Inc.: La empresa y razón social detrás de elementary y elementary OS.
+
+Este conjunto de nombres tienen las siguientes reglas:
+* Nunca deben ser traducidos. Es decir, nunca debe referirse como «elemental» o traducir el acrónimo _OS_ a _SO_
+* Nunca debe escribirse en mayúsculas, con la excepción del acrónimo si aparece. Al inicio de una frase debe mantenerse la minúscula. Si es posible, es recomendable modificar el texto para que _elementary_ o _elementary OS_ no sea la primera palabra de la frase.
+    * Se permite reemplazar OS (en caso de que aparezca) por «sistema operativo» si esto corrige la necesidad de tener elementary como la primera palabra de una frase.
+    * Si no hay manera de tener una traducción adecuada sin tener «elementary» al inicio de la frase, se permite como último recurso dejarlo tal como está.
+* Si elementary aparece sin el acrónimo _OS_, no es necesario añadírselo, ya que usualmente se refiere al equipo de trabajo. Si se mencionan las palabras _operative system_ se traducirá normalmente a «sistema operativo».
+* En la traducción de _elementary, Inc._ no se debe traducir la parte _Inc._, ya que no existe un equivalente hispanoamericano universal a la razón social de la empresa.
+
+### Ejemplos
+
+#### Ejemplo uno
+
+> elementary OS automatically checks your Internet connection when you connect to a new Wi-Fi network.
+
+Se traduce a:
+
+> El sistema operativo elementary comprueba automáticamente su conexión a Internet cuando se conecta con una red wifi nueva.
+
+#### Ejemplo dos
+
+> The elementary brand belongs to elementary, Inc., the company that guides and supports development of elementary products.
+
+Se traduce a:
+
+>La marca elementary pertenece a elementary, Inc., la compañía que guía y apoya el desarrollo de los productos elementary.
+
+#### Ejemplo tres
+
+> Get help installing elementary OS with our step-by-step guide.
+
+Se traduce a:
+
+> Aprenda a instalar elementary OS con nuestra guía paso a paso.
+
+## Nombres propios de aplicaciones
+
+En elementary estamos traduciendo algunos nombres de aplicaciones, pero otras no. Existen diferentes razones para traducir o no traducir ciertos nombres.
+
+En todo caso, el nombre de la aplicación debe tener siempre mayúsculas al inicio de cada palabra, excepto por artículos y conjunciones (por ej. «Centro de Aplicaciones», nótese la C y la A mayúsculas). 
+
+Esto rompe con la convención normal del español de no hacer capitalizaciones en cada palabra, pero para nombres propios se hace una excepción.
+
+También, al ser nombres propios, no es necesario distinguirlos de nombre extranjeros con el tipo letra itálica.
+
+### Razones para traducir nombres propios:
+
+* El nombre es un nombre de una aplicación de uso común, fácil de traducir (por ejemplo, _Calculator_ se traduce a «Calculadora»)
+* El nombre tiene un equivalente claro en español que no distraería de su uso diario (por ejemplo, _AppCenter_ se traduce a «Centro de Aplicaciones»)
+
+### Razones para **no** traducir nombres propios:
+
+* No existe una traducción clara en español que podría producir más confusión. Por ejemplo, _Sideload_ no tiene una palabra clara, existe «transferencia local», pero en el contexto de elementary, no se está usando exactamente como una transferencia local, sino más bien como una aplicación externa. De hecho, cuando se refiere a _sideload_ en las traducciones, es más apropiado hablar de una «instalación externa».
+* Cuando el nombre como tal no aporta nada a la interfaz del usuario o cuando es un nombre código que se usa más por los programadores y sería confuso traducirlo (por ej. _Granite_, siendo un conjunto de bibliotecas sobre GTK4 para programadores, causaría más confusión traducirlo porque nunca se refiere así internamente y no representa nada para un usuario común. Por lo tanto, lo dejamos sin cambios).
+
+## Nombres propios de los «plugs»
+
+Los plugs son los complementos externos que se utilizan en la aplicación de _Switchboard_ o Configuración del Sistema. En varios puntos de la traducción es común referirse a estos plugs. 
+
+Las reglas de nombre para estos plugs son similares a las aplicaciones, con la excepción de que solamente se conserva en mayúscula la primera palabra después del prefijo «configuración», pero las demás palabras permanecen en minúscula. 
+
+## Sobre las notas de las versiones
+
+Las notas de las versiones usualmente se pueden encontrar en las secciones _(extra)_ de Weblate.
+
+Estas secciones se refieren a notas de nuevas versiones respecto a correcciones, mejoras y nuevas funcionalidades.
+
+Se recomienda, al referirse a estas secciones, al ser notas de versiones, como elementos que __han cambiado, corregido o agregado,__ por lo que se recomienda utilizar verbos en pasado con pronombres reflexivos, particularmente el uso de _se_ si resulta posible.
+
+No es una obligación siempre usar esta forma gramatical, pero es altamente recomendado siempre que se pueda hacer.
+
+### Ejemplo
+
+El siguiente texto, referido a una nueva característica en la aplicación Code:
+
+> New custom dark and light elementary styles for the source view
+
+Se traducirá a:
+
+> Se agregó un nuevo estilo claro y oscuro de elementary para la vista de código
+
+## Guías de base
+
+Es importante mencionar que una gran parte de esta información se ha tomado de los equipos de traducción al español de Ubuntu y de Fedora, así como el diccionario de términos técnicos e informáticos de Microsoft y el Diccionario panhispánico de dudas de la RAE.
+
+Se recomienda leer y revisar frecuentemente estas guías para tener claro todos los aspectos de traducción al español para elementary OS.
+
+* Guía de estilo de Ubuntu al español: [Ubuntu Spanish Translators](https://wiki.ubuntu.com/UbuntuSpanishTranslators)
+* Guía de estilo de Fedora al español: [Fedora L10N Spanish Team](https://fedoraproject.org/wiki/L10N/Teams/Spanish/Diccionario)
+* Diccionario de términos técnicos e informáticos de Microsoft: [Microsoft Terminology](https://learn.microsoft.com/en-us/globalization/reference/microsoft-terminology) y [Microsoft Terminology Search](https://msit.powerbi.com/view?r=eyJrIjoiODJmYjU4Y2YtM2M0ZC00YzYxLWE1YTktNzFjYmYxNTAxNjQ0IiwidCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsImMiOjV9)
+* Manual de la RAE con diversos temas [Diccionario panhispánico de dudas](https://www.rae.es/dpd/)
+
+Si hay alguna contradicción entre estas guías y lo explicado aquí, este documento y el glosario de términos tienen precedencia sobre las guías base.
+
+

--- a/localization/localization-spanish/best-practices.md
+++ b/localization/localization-spanish/best-practices.md
@@ -1,0 +1,31 @@
+# Prácticas recomendadas al traducir en elementary
+
+A continuación tenemos una serie de buenas prácticas que pueden ser de utilidad a la hora de traducir al español.
+
+## ¡Leer la documentación de esta guía!
+
+Esta guía se creó para ser consultada y utilizada activamente, así como para ser modificada con nuevas palabras, buenas prácticas y advertencias de posibles errores. ¡Lo invitamos a usarla! Puede comenzar por  la [guía de estilo en español de elementary](README.md)
+
+## Tomarse el trabajo de traducción con calma y gusto
+
+Correr para hacer traducciones puede ser agotador y un poco frustrante. Este es un trabajo comunitario y voluntario, y las personas que lo hacen van y vienen. Los intereses y prioridades de cada quien cambian y puede que no halla nadie más que uno para hacer el trabajo. 
+
+También es posible que hagas sugerencias y alguien más decida tomarla o rechazarla.
+
+Está bien, no es necesario apresurarse, sentirse presionado o pensar que lo ha hecho mal. Es un trabajo de todos y la idea es pasarlo bien. Tómese las traducciones con calma y tómese su tiempo para hacerlo bien y con gusto. 
+
+En Weblate, las sugerencias siempre son bienvenidas y también es más que bienvenido comentar en una traducción en específico con preguntas o aclaraciones para poder tener completa colaboración entre los integrantes de la traducción.
+
+## Consultar las guías, referencias y glosarios oficiales de otros lugares para verificar traducciones
+
+Las guías base encontradas en la [guía de estilo en español de elementary](README.md) son importantes porque tiene años de experiencia de muchas personas en unificar, aplicar coherencia y sencillez a traducciones de muchos proyectos complejos de software. 
+
+Por lo tanto, se recomienda consultar tanto esta guía como sus guías base para tener todas las referencias a la hora de traducir. Sin embargo, es de notar que, si existen contradicciones entre las guías base y esta, esta guía tiene precedencia sobre las guías base.
+
+## Usar el buscador de Weblate y el glosario de términos de esta guía para comprobar la consistencia y coherencia en la traducción
+
+El buscador de Weblate puede ser muy útil para encontrar traducciones similares o de términos que pueden ya existir en otro proyecto. 
+
+No es necesario siempre tener que «inventar» la palabra o quemarse las pestañas encontrando la traducción correcta si ya alguien lo ha hecho antes con palabra y expresiones simples.
+
+Es importante tener esto en cuenta para mantener la consistencia y coherencia del español en todos los proyectos y poder replicar las mismas formas y expresiones en otras partes de las diferentes aplicaciones.

--- a/localization/localization-spanish/common-errors.md
+++ b/localization/localization-spanish/common-errors.md
@@ -1,0 +1,252 @@
+# Errores comunes y comportamientos a evitar cuando traduzca al español en elementary
+
+Aquí exponemos algunas prácticas no recomendadas que pueden causar problemas al hacer traducciones correctas para elementary.
+
+## Evite expresiones locales o coloquiales del español
+
+El fundamento de esta recomendación es que la traducción de elementary se pretende ser para un español internacional. Significa que se deben evitar palabras, jergas y expresiones locales que no sean universales en la región hispanoamericana.
+
+Esto es más difícil de lo que parece, ya que cada región tiene expresiones que, aunque pueden sonar bien en una zona, sonarán mal o fuera de tono en otra. La recomendación aquí es utilizar fuentes como el [diccionario de la lengua española RAE](https://dle.rae.es/) para obtener información sobre una palabra o expresión y observar si es algo específico de una región o no.
+
+Por esta misma razón, se debe ser lo más neutral posible al expresarse al usuario. Se debe evitar tanto el voseo y el tuteo, como formas coloquiales de referencia al usuario, por la misma razón expuesta anteriormente.
+
+## Ejemplo
+
+Este texto:
+
+> Type to test your settings
+>
+> You’re connected!
+
+Se traduciría a:
+
+> Escriba para probar su configuración
+>
+> ¡Está conectado!
+
+No se permiten formas como:
+
+> Escribe para probar tu configuración
+>
+> ¡Estás conectado!
+
+
+> Escribí y probá tu configuración
+>
+> ¡Vos estáis conectado!
+
+
+## ¡Tenga cuidado con el presente progresivo en inglés!
+
+El presente progresivo no siempre se debe traducir literalmente al español. Muchas veces en inglés, aunque se use esta conjugación, se está indicando algo en tiempo presente, futuro, o el verbo en infinitivo. 
+
+En resumen, la terminación _-ing_ no necesariamente representa un verbo terminado en «-ando» o «-iendo».
+
+### Ejemplo
+
+El siguiente texto:
+
+> After restarting you can set up a new user, or you can shut down now and set up a new user later.
+
+Se traduciría a:	
+
+> Después de reiniciar, puede configurar una cuenta de usuario nueva, o puede apagar ahora y configurarla más tarde.
+
+Nótese que utilizar el verbo _restarting_ como «reiniciando» no tendría sentido en esta frase, es necesario usar el verbo en infinitivo para que funcione.
+
+## Evite el uso excesivo de los adverbios (es decir, de palabras con «...mente» al final)
+
+Ejemplos de palabras pueden ser _actualmente, automáticamente, momentáneamente, especialmente, nuevamente, accidentalmente, permanentemente, etc_.
+
+Estas palabras no tienen nada malo _per se_. Lo que ocurre es que es muy común abusar de ellas, resultando en una traducción llena de este tipo de palabras.
+
+El uso de estas palabras es más tolerable en secciones de documentación o notas de versión. Pero es preferible intentar encontrar alternativas cuando se trata de elementos de interfaz de usuario.
+
+Sin embargo, esta no es una regla inmutable. Es posible que en algunos casos no se pueda evitar usar el adverbio, e incluso puede ser la mejor palabra dado el contexto. Pero se recomienda al menos tratar de encontrar alternativas si se siente que la traducción no se beneficia de la palabra actual.
+
+### Ejemplo
+
+Por ejemplo este texto del complemento de sonido de la Configuración del Sistema:
+
+>No applications currently emitting sounds. Applications emitting sounds will automatically appear here.
+
+Si lo traducimos con las palabras terminadas en «...mente» obtendríamos algo como esto:
+
+> No hay aplicaciones emitiendo sonidos _actualmente_. Las aplicaciones que emitan sonidos aparecerán aquí _automáticamente_.
+
+Nótese que hay mucha redundancia y aliteración con el uso excesivo del adverbio. Una traducción un poco mejor sería algo como esto:
+
+> No hay aplicaciones emitiendo sonidos _en este momento_. Las aplicaciones que emitan sonidos aparecerán aquí _de forma automática_.
+
+## Evite el exceso de cortesía en el español
+
+El español en herramientas técnicas, como aplicaciones y sistemas operativos, no se usan tantas palabras de cortesía, a diferencia del inglés. Muchas veces se considera superfluo e innecesario agregar estos detalles en español, resultando molesto (precisamente, la intención contraria de lo que desea).
+
+En particular, el uso de _please_ en inglés es muy común, pero que en español se suele omitir. Por lo general, el imperativo en español suena mejor a la hora de pedir aclaraciones o solicitar acciones.
+
+Una excepción a esta regla es cuando se hacen preguntas al usuario para realizar o confirmar una acción. En esta situación es recomendable utilizar la cortesía, en particular el uso del verbo «desear» y preguntar confirmaciones con «está seguro que...». Estamos prefiriendo el verbo «desear» sobre otros como «querer» y «está seguro que...» sobre «confirma que...».
+
+Otra excepción también surge cuando es claro que es un error o dificultad que está fuera del control del usuario o del sistema.
+
+Finalmente, es recomendado también enviar la cortesía al referirse a elementos del usuario y evitar la segunda persona. Por ejemplo, _your message_ es preferible traducirlo a «el mensaje» en vez de «su mensaje».
+
+### Ejemplos
+
+#### Ejemplo uno
+
+Este texto:
+
+> Please restart your system to finalize updates
+
+Se traduce así:
+
+> Reinicie el sistema para terminar de instalar las actualizaciones
+
+En este caso, evitamos traducir _please_ para evitar el exceso de cortesía y simplemente se usa la forma imperativa en la oración.
+
+#### Ejemplo dos
+
+Este texto a continuación:
+
+> An error occurred while processing the card. Please try again later. We apologize for any inconvenience caused.
+
+Se traduce de esta manera:
+
+> Se ha producido un error al procesar la tarjeta. Inténtelo de nuevo más tarde. Sentimos cualquier inconveniente causado.
+
+Nótese que la última parte sí se traduce, porque en este contexto (un error de procesamiento de pago de tarjeta) puede provocar un «pago fantasma» creando un inconveniente serio al usuario, pero fuera del control del sistema y del usuario. Por lo tanto en este caso, pedimos disculpas.
+
+#### Ejemplo tres
+
+Y finalmente este texto:
+ 	
+>Are you sure you want to Log Out?
+	
+Se traduce así:
+
+>¿Está seguro que desea cerrar la sesión?
+
+Aquí se usa la forma cortés de «desear» y solicitamos la confirmación con «está seguro», puesto que es una pregunta para una posible acción «irreversible» por decirlo de una forma.
+
+## En español, el uso de verbos modales y pronombres reflexivos es más común de lo que se cree
+
+Los pronombres reflexivos (_me, te, se, nos_) y los verbos modales (_deber, poder, tener, haber que_) son mucho más usados de lo que se cree en español. Por lo general, se utilizan para:
+
+* Referirse a eventos pasados o presentes cuando se producen errores o algún proceso falla.
+    * Lo común aquí es el uso de «se pudo», «no se pudo», «se ha producido» etc.
+* Traducir palabras en inglés como _may_ a su respectivo verbo modal, dependiendo del contexto.
+* Al hablar de actualizaciones y notas de versión, el pronombre reflexivo «se» es común de usar para hablar de cambios y demás.
+
+Una excepción de los verbos modales es con «haber que», «hubo», etc. Usualmente, se prefiere el uso del pronombre reflexivo «se» para este tipo de expresiones.
+
+### Ejemplos
+
+#### Ejemplo uno
+
+Este texto:
+
+> This may have been caused by sideloaded or manually compiled software, a third-party software source, or a package manager error. Manually refreshing updates may resolve the issue.
+
+Se traduce a:
+
+> Esto puede deberse a instalaciones externas o aplicaciones compiladas manualmente, una fuente de aplicaciones de terceros, o un error en el gestor de paquetes. Refrescar las actualizaciones podría solucionar el problema.
+
+Nótese el uso diferente de los verbos modales en ambas acepciones de _may_. Existe una intención ligeramente diferente en cada oración.
+
+#### Ejemplo dos
+
+Este texto, en relación a una nota de actualización de versión
+
+> Improve brightness in the dark style
+
+Se traduce a:	
+
+> Se mejoró el brillo en el estilo oscuro
+
+### Ejemplo tres
+
+El texto:
+
+> There was an unexpected error while sending your message.
+
+Se podría traducir a:
+
+> Hubo un error inesperado mientras se enviaba su mensaje.
+
+Pero la semantica resulta un poco extraña. El pronombre reflexivos nos ayuda a mencionar que este fue un evento que ya ocurrió, fue registrado
+
+en cuyo caso preferimos traducilor a:
+
+> Se ha producido un error inesperado al enviar el mensaje.
+
+### Ejemplo cuatro
+
+Los siguientes textos: 
+
+> Could not save configuration
+>
+> Firewall rules can't be changed without the required system permission.
+
+Se traducen a:
+
+> No se pudo guardar la configuración	
+>
+> Las reglas del cortafuegos no se pueden cambiar sin los permisos necesarios.
+
+## Tenga en cuenta las distinciones entre nombres simples y las aplicaciones con nombre propio
+
+A la hora de traducir, es importante  poder distinguir entre los nombres propios de las aplicaciones versus el uso común de las palabras que representan. 
+
+En particular, una aplicación, servicio o _plug_, al ser un nombre propio, debe ir siempre en su formato correcto, especificado en el glosario de términos y, si es posible, evitar referirse a la aplicación antecedida de un artículo (por ejemplo, es «Correo», no «el Correo»).
+
+Puede consultar un glosario de términos de todos los nombres propios de las aplicaciones básicas de elementary OS en el [glosario de términos](glossary.md).
+
+## Evite hacer traducciones absolutamente literales
+
+Las traducciones literales nunca son recomendadas. Es muy común querer traducir palabra por palabra la forma verbal del inglés para simular el flujo del idioma original. El español tiene una estructura diferente y utiliza modismos y estructuras verbales de manera distinta que el inglés.
+
+La sugerencia de esta guía es siempre leer la frase completa primero y entender el contexto detrás de ella para luego traducir. Trate de ver el todo de la frase y no sus palabras individuales para enviar el mismo mensaje, así no resulte necesariamente en una traducción literal.
+
+Es recomendable evitar _transliterar_ o _traducir palabra a palabra_, es decir, leer la primera palabra, traducirla, ir a la siguiente, traducirla, etcétera. Esto suele crear frases extrañas con una composición que no se siente natural al idioma español.
+
+### Ejemplo
+
+Consideremos esta frase:
+
+> This site uses cookies for incremental improvements. You may find the services function without them but at a reduced usability.
+
+La traducción literal tanto en palabras como gramatical resultaria en:
+
+> Este sitio usa _cookies_ para mejoras incrementales. Usted puede encontrar que los servicios funcionen sin ellas pero a una reducida usabilidad.
+
+Pero esto no se siente natural, tanto en vocablos como en gramática. Una traducción centrada más en la comprensión general de la frase sería algo como lo siguiente:
+
+> Este sitio utiliza _cookies_ para realizar mejoras continuas. Puede utilizar los servicios sin ellas pero con una usabilidad reducida.
+
+## Evite traducciones automáticas con traductores
+
+Es bastante común caer en la tentación de utilizar servicios de traducción como [el traductor de Google](https://translate.google.com) para obtener una traducción rápida.
+
+En principio, no tenemos objeciones sobre el uso de traductores para una base inicial, pero les suplicamos a las personas que hagan esto que revise _dos, tres o cuatro veces la traducción proporcionada por el traductor_.
+
+Muchas veces estos traductores hacen _traducciones literales_. Esto significa que deciden traducir términos de manera literal, sin conocer el contexto del texto o su nivel técnico.
+
+Por ejemplo, muchas veces se traducen palabras de nombres en inglés sin posibles traducciones propias al término técnico como __ (en el contexto de instalaciones externas)  o _cookies_ (en el contexto web), que no tendrían cabida en la traducción final.
+
+O peor aún, a veces ofrecen traducciones que es posible no tengan cabida en lo que se refiere. Por ejemplo, _sideload_ puede llegar a traducirse como «transferencia local» que, aunque técnicamente correcto, en el contexto de elementary no sería el término preciso y puede llegar a confundir en el contexto de elementary (en elementary estamos usando «instalación externa» por ejemplo)
+
+Los traductores también tienden a _transliterar_ las frases. Esto resulta muchas veces en una traducción que, como se ha expuesto anteriormente, causa un español extraño y con poco sentido.
+
+
+# Tabla con errores simples al traducir
+
+A continuación se expone una tabla con posibles errores comunes que se suelen escribir a la hora de hacer traducciones al idioma español, con su corrección y notas del razonamiento.
+
+| Frase original | Correcto | Incorrecto | Notas o justificación |
+| --- | --- | --- | --- |
+| Click with the secondary mouse button | Haga clic con el botón secundario del ratón | _Haga clic con el botón derecho del ratón._ | Existen usuarios que usan el ratón con la mano izquierda, así que el botón derecho se refiere al botón secundario (la excepción es cuando explícitamente se refiera al botón físico del ratón). Las acciones de un botón son primario, secundario y central. |
+| Whoops! That link has expired! | ¡Vaya! ¡Este enlace ha caducado! | _Vaya! Este enlace ha caducado!_ | Las frases de interrogación y exclamación siempre llevan signos tanto al comienzo como al final de la frase expresada. |
+| We Have Shipped Your Order | Hemos enviado su pedido | _Hemos Enviado Su Pedido_ | Las mayúsculas compuestas no se permiten en español (esto es, una mayúscula al inicio en cada palabra). Sin embargo, se debe tener cuidado de no descapitalizar un nombre propio. Las siglas tampoco de descaptilizan |
+| Spring, Fall, March, November, Tuesday, Friday | Primavera, otoño, marzo, noviembre, martes, viernes | _Primavera, Otoño, Marzo, Noviembre, Martes, Viernes_ | Los días, meses y las estaciones no utilizan mayúsculas en español, a menos que comiencen una frase |
+| "elementary OS is different… a beautiful and powerful operating system." | «elementary OS es diferente… un sistema operativo hermoso y potente». | _«elementary OS es diferente… un sistema operativo hermoso y potente.»_ | Los puntos siempre van por fuera de las comillas y los paréntesis en español. |
+| System Settings offers several advantages to OEMs shipping elementary OS. | La Configuración del Sistema posee varía ventajas para fabricantes OEM que ofrezcan elementary OS. | _La Configuración del Sistema posee varía ventajas a las OEMs que ofrezcan elementary OS._ | Las siglas no tienen plural en español, si ver siglas plurales, se debe buscar una alternativa o, como mínimo, utilizar los  determinantes plurales (los, las). |

--- a/localization/localization-spanish/common-errors.md
+++ b/localization/localization-spanish/common-errors.md
@@ -54,6 +54,55 @@ Se traduciría a:
 
 Nótese que utilizar el verbo _restarting_ como «reiniciando» no tendría sentido en esta frase, es necesario usar el verbo en infinitivo para que funcione.
 
+## Evite el uso de comillas inglesas o sencillas
+
+En español, las comillas inglesas (“, ” o ") o comillas sencillas (` o ') no se utilizan a menos que sea absolutamente necesario. De manera predeterminada, siempre usaremos comillas españolas o angulares (« y ») para textos comunes para el usuario.
+
+Excepciones para utilizar las comillas inglesas o de hacker son:
+
+* Secciones de código de ejemplo de lenguajes de programación como Vala, donde la sintaxis exige el uso de comillas inglesas o comillas simples.
+* Etiquetas de navegador internas del lenguaje HTML, Markdown que exigen el uso de comillas simples y no se pueden cambiar. De lo contrario, el formato de estos lenguajes se rompería.
+
+En Linux, estos caracteres se pueden escribir con la combinación de teclas Alt Gr + Z y Alt Gr + X, respectivamente, con las distribuciones de teclado hispanoamericanas con teclas muertas. En Windows esto se realiza con la combinación Alt + 174 y Alt + 175, respectivamente.
+
+El sitio web de Weblate también ofrece botones que pueden ser presionados con el ratón para colocar estos caracteres.
+
+### Ejemplos
+
+### Ejemplo uno
+
+El texto:
+
+> The program "io.elementary.calendar" may not be installed
+
+Se traduce a:
+
+> Es posible que el programa «io.elementary.calendar» no esté instalado
+
+### Ejemplo dos
+
+> Take this time to read the \<a href="/docs/learning-the-basics">getting started\</a> guide to learn about your new operating system.
+
+Se traduce a:
+
+> Dedique un momento a leer la \<a href="/docs/learning-the-basics">guía de primeros pasos\</a> para aprender a utilizar su nuevo sistema operativo.
+ 
+Nótese que no se traducen las comillas de la etiqueta HTML, ya que es una exigencia para que funcione correctamente y la dejamos como está.
+
+## Evite reemplazar las etiquetas de programación o HTML de un texto
+
+Las etiquetas HTML y otros aspectos de código HTML (o de lenguajes de programación como Vala) tienen una exigencia de sintaxis que no debe ser alterada, ya que rompería el formato HTML y puede causar problemas. Estas partes del texto nunca deben ser traducidas.
+
+### Ejemplo
+
+> You can also secondary-click a window's header bar and choose \<strong\>Resize\</strong\> or press \<kbd\>Alt\</kbd\>\<kbd\>F8\</kbd\> to enter resize mode.
+
+Se traduce a:
+
+> También puede hacer clic con el botón secundario en la barra de encabezado de una ventana y elegir \<strong\>Redimensionar\</strong\> o presionar \<kbd\>Alt\</kbd\>\<kbd\>F8\</kbd\> para ingresar al modo redimensionar.
+
+Nótese que las etiquetas _\<strong\>_ y _\<kbd\>_ no se traducen. Se conserva su estructura para que el formato HTML dibuje correctamente el resultado final.
+
 ## Evite el uso excesivo de los adverbios (es decir, de palabras con «...mente» al final)
 
 Ejemplos de palabras pueden ser _actualmente, automáticamente, momentáneamente, especialmente, nuevamente, accidentalmente, permanentemente, etc_.

--- a/localization/localization-spanish/common-errors.md
+++ b/localization/localization-spanish/common-errors.md
@@ -274,17 +274,22 @@ Pero esto no se siente natural, tanto en vocablos como en gramática. Una traduc
 
 ## Evite traducciones automáticas con traductores
 
-Es bastante común caer en la tentación de utilizar servicios de traducción como [el traductor de Google](https://translate.google.com) para obtener una traducción rápida.
+Es bastante común caer en la tentación de utilizar servicios de traducción como [el traductor de Google](https://translate.google.com) para obtener una traducción rápida. 
 
-En principio, no tenemos objeciones sobre el uso de traductores para una base inicial, pero les suplicamos a las personas que hagan esto que revise _dos, tres o cuatro veces la traducción proporcionada por el traductor_.
+_No se recomienda el uso de estos servicios y, de hecho, se prefiere evitarlos completamente._
 
-Muchas veces estos traductores hacen _traducciones literales_. Esto significa que deciden traducir términos de manera literal, sin conocer el contexto del texto o su nivel técnico.
+Existen múltiples razones para ello:
 
-Por ejemplo, muchas veces se traducen palabras de nombres en inglés sin posibles traducciones propias al término técnico como __ (en el contexto de instalaciones externas)  o _cookies_ (en el contexto web), que no tendrían cabida en la traducción final.
+* Estos servicios gratuitos muchas veces son _exclusivamente para uso personal_ y los términos legales de estos servicios suelen ser complicados de usar para una organización como elementary, Inc., exigiendo el pago de licencias comerciales para un proyecto como elementary OS.
 
-O peor aún, a veces ofrecen traducciones que es posible no tengan cabida en lo que se refiere. Por ejemplo, _sideload_ puede llegar a traducirse como «transferencia local» que, aunque técnicamente correcto, en el contexto de elementary no sería el término preciso y puede llegar a confundir en el contexto de elementary (en elementary estamos usando «instalación externa» por ejemplo)
+* Muchas veces estos traductores hacen _traducciones literales_. Esto significa que deciden traducir términos de manera literal, sin conocer el contexto del texto o su nivel técnico. <br>
+Por ejemplo, muchas veces se traducen palabras de nombres en inglés sin posibles traducciones propias al término técnico como _cookies_ (en el contexto web, que traducen a «galletas») o _plugs_ (en el contexto de los complementos de elementary, que traducen a «enchufe»), que no tendrían cabida o sentido en la traducción final.
 
-Los traductores también tienden a _transliterar_ las frases. Esto resulta muchas veces en una traducción que, como se ha expuesto anteriormente, causa un español extraño y con poco sentido.
+* A veces los traductores ofrecen traducciones de palabras que no tienen un perfecto significado a lo que se refiere. Por ejemplo, _sideload_ puede llegar a traducirse como «transferencia local» o «carga lateral» que, aunque técnicamente correctos, en el contexto de elementary no serían los términos precisos y puede llegar a confundir (en elementary estamos usando «instalación externa» para esta palabra).
+
+* Los traductores tienden a _transliterar_ las frases. Esto resulta muchas veces en una traducción que, como se ha expuesto anteriormente, causa un español extraño y con poco sentido.
+
+Por todas estas razones se concluye que no se pueden usar estos servicios de manera satisfactoria y desafortunadamente no podemos recomendar su uso.
 
 
 # Tabla con errores simples al traducir

--- a/localization/localization-spanish/glossary.md
+++ b/localization/localization-spanish/glossary.md
@@ -61,6 +61,7 @@ Esta tabla la tomamos de la «Guía de estilo de Ubuntu al español»: [Ubuntu S
 | Click | clic |
 | Double click | Doble clic |
 | Alt | Alt |
+| Alt Gr | Alt Gr |
 | Backspace | Retroceso |
 | Caps Lock | Bloq Mayús |
 | Ctrl | Ctrl |

--- a/localization/localization-spanish/glossary.md
+++ b/localization/localization-spanish/glossary.md
@@ -1,0 +1,162 @@
+# Glosario de términos para elementary OS en español
+
+Aquí va a encontrar un glosario general de términos para diferentes usos y nobres en elementary OS.
+
+## Términos generales
+
+A continuación se encuentra una lista de términos generales que pueden aparecer a lo largo de los varios proyectos de elementary. Se conservan aquí para obtener un estándar de base para todas las aplicaciones.
+
+| Nombre en inglés | Nombre en español | Notas |
+| --- | --- | --- |
+| Click | Clic | A pesar de que «pulsar» es correcto, se prefiere «clic» o «hacer clic» en lo posible |
+| Manage, manager | Gestionar, gestor | Se puede usar «administrar» pero se prefiere primero ver si «gestión», «gestor» o «gestionar» funciona bien en el contexto. |
+| Management | Administrar | Se la misma manera que manage, si desea usar «gestionar», asegúrese de que suene bien en contexto. |
+| Toggle | Activar o desactivar | Nótese que es toda la frase «activar o desactivar». Es posible usar «mostrar u ocultar» «alternar» o «intercambiar» si el contexto lo amerita. |
+| Always on top | Siempre visible | Evitar usar «siempre encima» |
+| App | Aplicación | En ningún contexto usaremos la acepción «app» o cualquier otra abreviatura en español |
+| Daemon | Servicio | En el mundo Linux es común usar _daemon_ o «demonio» en español. Sin embargo para un usuario final en español es más común usar «servicio» como término universal |
+| Icon | Icono | Nótese que estamos utilizando la acepción que no tiene tilde |
+| Wallpaper | Fondo de escritorio | |
+| Accent color | Color de énfasis | |
+| Multitasking | Multitarea | |
+| Portal | Portal | Relativo al sistema de portales de flatpak. Dependiendo del contexto se puede usar como nombre propio |
+| Plug | Plug o complemento | Relativo al sistema de complementos de elementary para Switchboard. Los _plugs_ son el nombre interno de estos elementos de configuración. |
+| Setting | Configuración  | Para el usuario, se usa de manera general de la misma forma que en inglés _settings_, traducido a «Configuración de...» (por ejemplo, «Configuración de Bluetooth») internamente se sigue usando «plug» como nombre interno |
+| Stylus | Lápiz o lápiz digital | |
+| Device | Equipo o dispositivo | En elementary en español estamos haciendo la distinción de «equipo» que se usa al refersire al computador mismo. «Dispositivo» se usa para cualquier otro dispositivo externo que no sea el computador |
+| Terminal | Terminal | Por lo general usamos la acepción masculina (_el terminal_). Pero no hay ningún problema en usar la acepción femenina (_la terminal_) si el mensaje lo amerita o se siente mejor en la traducción. |
+| Command, Commands | Comando, comandos | Evitar la acepción «orden» |
+| Shell | Intérprete de comandos | Existen excepciones para ciertos casos, como SSH (_Secure Shell_) o si no es claro cuando Shell signifique esto.  Existe una excepción al referirse a entornos de escritorio (tal como _desktop shell_, o _Patheon desktop shell_), en el cual usaremos «entorno de escritorio» |
+| Runtime | Entorno de ejecución | |
+| Dekstop runtime | Entorno de escritorio | Esto es igual a _desktop shell_ en inglés. Aunque técnicamente lo correcto es «entorno de ejecución de escritorio», es demasiado largo y comúnmente se omite la palabra «ejecución» para el escritorio |
+| Date & Time | Fecha y hora | En español nunca se utiliza el símbolo «&» para conjunciones, a menos que sea parte ineludible de un nombre propio |
+| Sharing | Uso compartido | Esto es en el contexto de compartir archivos, imágenes, música y otros contenidos con otros dispositivos en la red |
+| Hardware | Hardware o dispositivo(s) | Es preferible utilizar la palabra «dispositivo(s)» si tiene sentido utilizarla en el contexto. |
+| Software | Software o aplicación/aplicaciones | Es preferible utilizar la palabra «aplicación» o «aplicaciones» si tiene sentido utilizarla en el contexto. |
+| Hot Corner | Esquina activa | |
+| Workspace | Área de trabajo | |
+| Display | Pantalla | Se puede utilizar «monitor» cuando se refiera exclusivamente al dispositivo físico como tal. En cualquier otro contexto, se usa «pantalla». Es decir, _display resolution_ se traduciría como «resolución de pantalla», no «resolución de monitor». |
+| Refresh Rate | Frecuencia de actualización  | |
+| Aspect ratio | Relación de aspecto | |
+| Home folder | Carpeta personal | Esto es relativo a la carpeta personal de cada usuario para guardar descargas, documentos, imágenes, video, música, etc. Específicamente es la dirección _/home/nombre-de-usuario_/ en el sistema de archivos |
+| Streaming | Transmisión, transmitir | |
+| Locale | Configuración regional | Es posible decir «región» o «regional» si la traducción lo amerita para evitar textos muy largos o redundantes |
+| Maximize | Maximizar | |
+| Unmaximize | Restaurar | Evitar el uso de «deshacer maximizado» o «desmaximizar» |
+| Website | Sitio web | En general se prefiere «sitio web», pero es posible usar «página web» si el contexto lo amerita |
+
+## Términos del teclado y botones
+
+Los nombres de las teclas en español son diferentes a las del inglés y deben traducirse. A continuación se ofrecen las traducciones comunes para las teclas modificadoras del teclado y el ratón.
+
+Esta tabla la tomamos de la «Guía de estilo de Ubuntu al español»: [Ubuntu Spanish Translators](https://wiki.ubuntu.com/UbuntuSpanishTranslators)
+
+| Nombre en inglés | Nombre en español |
+| --- | --- | 
+| Primary mouse button | Botón primario del ratón | 
+| Secondary mouse button | Botón secundario del ratón | 
+| Right mouse button | Botón derecho del ratón | 
+| Left mouse button | Botón izquierdo del ratón | 
+| Middle mouse clic | Clic del botón central del ratón | 
+| Click | clic |
+| Double click | Doble clic |
+| Alt | Alt |
+| Backspace | Retroceso |
+| Caps Lock | Bloq Mayús |
+| Ctrl | Ctrl |
+| Del | Supr |
+| End | Fin |
+| Enter | Intro |
+| Esc | Esc |
+| Home | Inicio |
+| Ins | Ins |
+| Num Lock | Bloq Num |
+| Pause | Pausa |
+| SysReq | Pet Sis |
+| PgDn | Av Pág |
+| PgUp | Re Pág |
+| Print Screen | Impr Pant |
+| Scroll Lock | Bloq Despl |
+| Shift | Mayús |
+| Spacebar | Barra espaciadora |
+| Space | Espacio |
+| Tab | Tab |
+
+## Términos técnicos de informática y de _Linux_
+
+En elementary no estamos traduciendo todos los términos técnicos al español, dado el uso extenso de algunos en inglés y comúnmente aceptados. 
+
+Sin embargo, una de las reglas es tratar de traducir la mayor cantidad de términos  (así sean menos conocidos), siempre y cuando sea claro el significado o si existe una palabra aceptada, así no sea muy popular.
+
+Una buena parte de estas palabras que hemos traducido parten del diccionario informático _[Microsoft Terminology](https://learn.microsoft.com/en-us/globalization/reference/microsoft-terminology)_.
+
+Si no existe un término aquí, es recomendado hacer una búsqueda por el diccionario de _Microsoft_ para encontrar un equivalente. De no haber uno, se recomienda entonces, en la medida de lo posible, encontrar un uso conocido en algún programa de amplio uso, o encontrar una traducción apta.
+
+Hay términos que en ciertos contextos no tienen una traducción satisfactoria, y eso está bien. El punto es tratar de que la mayoría de los términos tengan su equivalente, pero no esperamos que sea posible para todos.
+
+## Nombres propios de las aplicaciones
+
+A continuación se muestra una tabla de todos los nombres propios de las aplicaciones y servicios de elementary
+
+| Nombre en inglés | Nombre en español | Notas |
+| --- | --- | --- |
+| AppCenter | Centro de Aplicaciones  | |
+| Calculator | Calculadora  | |
+| Calendar | Calendario*  | |
+| Camera | Cámara*  | |
+| Code | Code  | Se conserva el nombre original en concordancia con otras aplicaciones que hacen algo similar, como por ejemplo *Microsoft VS Code* |
+| Files | Archivos*  | |
+| Mail | Correo*  | |
+| Music | Música*  | |
+| Photos | Fotos*  | |
+| Screenshot | Captura de Pantalla*  | |
+| Shortcuts | Atajos*  | |
+| Tasks | Tareas*  | |
+| Terminal | Terminal*  | |
+| Feeback | Comentarios* | |
+| Videos | Videos*  | Estamos usando el vocablo sin tilde, que es válido en español y cumple con el español internacional sobre «vídeos» |
+| Web | Web*  | |
+| Epiphany | Epiphany  | El nombre antiguo (ahora  interno) del navegador web de GNOME, conservamos el nombre original y no se traduce |
+| Installer | Instalador*  | Conocido también como «Instalador de elementary» |
+| Onboarding | Bienvenida | |
+| Multitasking | Multitarea*  | Conocido también como «Vista Multitarea» (nótese la V mayúscula) |
+| Multitasking &amp; Window Management | Multitarea y gestión de ventanas | |
+| System Settings | Configuración del Sistema* | |
+| Switchboard | Nombre interno de la herramienta de «Configuración del Sistema». No vemos motivo para cambiarlo, ya que es un nombre interno y los programadores preferirían verlo así.  | |
+| Sideload | Sideload | No hay una traducción completamente correcta para esta aplicación. Lo más cercano es «transferencia local» pero no representa correctamente como se usa en elementary. La palabra ordinaria utilizamos «instalación externa» |
+| Wingpanel | Wingpanel | El nombre interno de «Panel» que conservamos en inglés  |
+| Panel | Panel | El nombre interno del programa es Wingpanel, pero en la documentación externa de le conoce como _Panel_ que traducimos directamente al español |
+| Dock | Dock | Se ha propuesto antes «Lanzador», pero por ahora hemos consideramos que Dock se conserve |
+
+*Para estas aplicaciones, es importante notar cuando se está usando la palabra como el término común, o si se está refiriendo a la aplicación como tal.
+
+## Nombres propios de los complementos o «plugs»
+
+A continuación, se presenta una tabla con los nombres de todos los complementos o «plugs» de la aplicación _Switchboard_.
+
+| Nombre en inglés | Nombre en español |
+| --- | --- |
+| System Settings | Configuración del Sistema | |
+| Settings Daemon | Servicio de Configuraciones | |
+| Applications Settings | Configuración de Aplicaciones | |
+| Desktop Settings | Configuración del Escritorio | |
+| Display Settings | Configuración de Pantalla | |
+| Sound Settings | Configuración de Sonido |
+| Keyboard Settings | Configuración de Teclado | |
+| Dock & Panel | Dock y Panel* | |
+| Language & Region Settings | Configuración de Idioma y región | |
+| Date & Time Settings | Configuración de Fecha y hora | |
+| User Accounts Settings | Configuración de Cuentas de usuario | |
+| Notifications Settings | Configuración de Notificaciones | |
+| Network Settings | Configuración de Red | |
+| Security & Privacy Settings | Configuración de Seguridad y privacidad | |
+| Sharing Settings / Sharing | Configuración de Uso compartido / Uso compartido | |
+| Bluetooth Settings | Configuración de Bluetooth | |
+| Screen Time & Limits Settings | Configuración de Tiempo en pantalla y límites | |
+| Wacom Settings | Configuración de Wacom | |
+
+_*Al ser ambos nombres propios, tanto Dock como Panel tienen mayúsculas en este contexto_
+
+Es de notar que todos los plugs conservan sus nombres propios al hablar de la configuración de los mismos. Es decir, al utilizar «Configuración de...» como prefijo del plug.
+
+Por ejemplo, «Sistema» sería «Configuración del Sistema», y «Fecha y hora» cambiaría a «Configuración de Fecha y hora»

--- a/localization/translations.md
+++ b/localization/translations.md
@@ -20,6 +20,14 @@ By default, you will only be able to suggest translations. If you would like per
 
 When translating you may encounter a situation where you have to decide between several ways of saying the same thing. In these situations we refer to the Ubuntu [general translator guide](https://help.launchpad.net/Translations/Guide), and for language specific issues, we follow Ubuntu's [team translation guidelines](https://translations.launchpad.net/+groups/ubuntu-translators). Following these guidelines ensures uniform translations, while also allowing anyone to contribute.
 
+### Specific Language Style Guides
+
+Some language teams have created guides specific to their language to support their own translation efforts. You can check a list of the current available guides here:
+
+* [Spanish translation](localization-spanish/README.md)
+
+_Please note that each style guide will use their own language to explain their details. Expect these pages to not be available in English._
+
 ## Using a Desktop Translation App
 
 If you don't want to translate using Weblate, or want to make a lot a changes at once, you can also translate offline. To do so:


### PR DESCRIPTION
Hello,

I've been translating the missing keywords for Spanish in elementary Os for the last month or so.

So in the midst of finishing all the missing keywords and reaching almost 100% translation of the Spanish language (some things are missing because of lock) I wanted to add a custom guide for Spanish translation.

This adds a custom localization guide just for Spanish, but it also adds a small addendum for other languages to pour in their own translation guide.

The motivation behind it is that sometimes a translator will fade away for one reason or another, and so it would e good to have some sort of simple guide to handle base translations.

The sections for the Spanish language are:

* The main section as a README.md, as the style guide and a small table of contents at the top.
    * This describes some basics in translating, a basic guide just for elementary words, and also describe the philosophy for Spanish and the main aim of the guide (like, saying it's not an immutable bible it's just a document with suggestions).
    * it also credits the base guides and resources taken for some of its documentation (Basically some Ubuntu and Fedora style guides in Spanish, and the official RAE institute dictionaries and manuals)
* A glossary of terms, (that is, technical and simple terms, application and plug names, and simple terms like keyboard key names).
* A page describing good practices to apply when translating
* A page describing potential errors and mistakes when translating, along with examples on dos and don'ts.

All the specific pages are in Spanish, though. I'm using the main language to explain all of this, since it makes sense to have the language guide be in the same language.

If anyone knows Spanish, I encourage you to read it and check out fit here are any inconsistencies or something that is not clear.

Also, let me know if this makes sense here or if here is a better place for it.

Thanks